### PR TITLE
Softmax + plotting entropy/probs

### DIFF
--- a/environment.py
+++ b/environment.py
@@ -21,6 +21,9 @@ class CarRacingEnv:
         self.env = FrameSkipper(self.env, 4)
         print(self.env.observation_space)
 
+    def max_episode_steps(self):
+        return self.spec().max_episode_steps
+
     def step(self, action):
         return self.env.step(action)
 

--- a/policy.py
+++ b/policy.py
@@ -18,7 +18,7 @@ class Policy(nn.Module):
             nn.Linear(64 * 22 * 22, 512),
             nn.ReLU(),
             nn.Linear(512, outputs),
-            nn.LogSoftmax(dim=-1)
+            nn.Softmax(dim=-1)
         )
         self.saved_log_probs = []
         self.rewards = []

--- a/trainer.py
+++ b/trainer.py
@@ -20,7 +20,7 @@ class Trainer:
         self.last_epoch = self.policy.load_checkpoint(config['params_path'])
         self.optimizer = torch.optim.Adam(self.policy.parameters(), lr=config['lr'])
 
-    def select_action(self, state):
+    def select_action(self, state, iteration):
         if state is None:  # First state is always None
             # Adding the starting signal as a 0's tensor
             state = np.zeros((self.input_channels, 96, 96))
@@ -33,6 +33,8 @@ class Trainer:
         m = torch.distributions.Categorical(probs)
         action = m.sample()
         self.policy.saved_log_probs.append(m.log_prob(action))
+        self.writer.add_scalar('action prob', m.log_prob(action), iteration)
+        self.writer.add_scalar('entropy', m.entropy(), iteration)
         return available_actions[action.item()]
 
     def episode_train(self, iteration):
@@ -71,8 +73,8 @@ class Trainer:
             i_episode = i_episode + self.last_epoch
             # Collect experience
             state, ep_reward = self.env.reset(), 0
-            for t in range(self.env.spec().max_episode_steps):  # Protecting from scenarios where you are mostly stopped
-                action = self.select_action(state)
+            for t in range(self.env.max_episode_steps()):  # Protecting from scenarios where you are mostly stopped
+                action = self.select_action(state, i_episode * self.env.max_episode_steps() + t)
                 state, reward, done, _ = self.env.step(action)
                 self.policy.rewards.append(reward)
 


### PR DESCRIPTION
Looks like the entropy decreases dramatically to 0 after the first episode (therefore log probs goes to 0 too).
Hypothesis:  Something might be wrong on the training

![entroy-probs-softmax-local](https://user-images.githubusercontent.com/613814/109720637-a3575b00-7baa-11eb-953e-59b47d9c433a.png)

![running-reward-loss-softmax](https://user-images.githubusercontent.com/613814/109720635-a2bec480-7baa-11eb-8b9a-d483420e3611.png)
