### PR TITLE
Apply random actions epsilon times (and decay)

### DIFF
--- a/environment.py
+++ b/environment.py
@@ -21,6 +21,9 @@ class CarRacingEnv:
         self.env = FrameSkipper(self.env, 4)
         print(self.env.observation_space)
 
+    def max_episode_steps(self):
+        return self.spec().max_episode_steps
+
     def step(self, action):
         return self.env.step(action)
 

--- a/main.py
+++ b/main.py
@@ -19,6 +19,8 @@ if __name__ == "__main__":
         'stack_frames': 4,
         'device': device,
         'params_path': './params/policy-params.dl',
+        'eps': 0.4,
+        'eps_decay_episodes': 300,
         'train': True
     }
 

--- a/main.py
+++ b/main.py
@@ -20,7 +20,7 @@ if __name__ == "__main__":
         'device': device,
         'params_path': './params/policy-params.dl',
         'eps': 0.4,
-        'eps_decay_episodes': 300,
+        'eps_decay_episodes': 250,
         'train': True
     }
 

--- a/policy.py
+++ b/policy.py
@@ -8,15 +8,15 @@ class Policy(nn.Module):
     def __init__(self, inputs=4, outputs=8):
         super(Policy, self).__init__()
         self.pipeline = nn.Sequential(
-            nn.Conv2d(inputs, 6, kernel_size=3, stride=2, padding=1),  # [32, 48, 48]
+            nn.Conv2d(inputs, 12, kernel_size=3, stride=2, padding=1),  # [12, 48, 48]
             nn.ReLU(),
-            nn.MaxPool2d(2),  # [32, 24, 24]
-            nn.Conv2d(6, 24, kernel_size=3),  # [64, 22, 22]
+            nn.MaxPool2d(2),  # [12, 24, 24]
+            nn.Conv2d(12, 24, kernel_size=3),  # [24, 22, 22]
             nn.ReLU(),
-            nn.MaxPool2d(2),  # [64, 11, 11]
-            nn.Conv2d(24, 32, 4),  # [64, 8, 8]
+            nn.MaxPool2d(2),  # [24, 11, 11]
+            nn.Conv2d(24, 32, 4),  # [32, 8, 8]
             nn.ReLU(),
-            nn.MaxPool2d(2),  # [64, 4, 4]
+            nn.MaxPool2d(2),  # [32, 4, 4]
             nn.Flatten(),
             nn.Linear(32 * 4 * 4, 256),  # [ 512, 256 ]
             nn.ReLU(),

--- a/policy.py
+++ b/policy.py
@@ -8,17 +8,22 @@ class Policy(nn.Module):
     def __init__(self, inputs=4, outputs=8):
         super(Policy, self).__init__()
         self.pipeline = nn.Sequential(
-            nn.Conv2d(inputs, 32, 3),  # [32, 94, 94]
+            nn.Conv2d(inputs, 6, kernel_size=3, stride=2, padding=1),  # [32, 48, 48]
             nn.ReLU(),
-            nn.MaxPool2d(2),  # [32, 47, 47]
-            nn.Conv2d(32, 64, 4),  # [64, 44, 44]
+            nn.MaxPool2d(2),  # [32, 24, 24]
+            nn.Conv2d(6, 24, kernel_size=3),  # [64, 22, 22]
             nn.ReLU(),
-            nn.MaxPool2d(2),  # [64, 22, 22]
+            nn.MaxPool2d(2),  # [64, 11, 11]
+            nn.Conv2d(24, 32, 4),  # [64, 8, 8]
+            nn.ReLU(),
+            nn.MaxPool2d(2),  # [64, 4, 4]
             nn.Flatten(),
-            nn.Linear(64 * 22 * 22, 512),
+            nn.Linear(32 * 4 * 4, 256),  # [ 512, 256 ]
             nn.ReLU(),
-            nn.Linear(512, outputs),
-            nn.Softmax(dim=-1)
+            nn.Linear(256, 128),
+            nn.ReLU(),
+            nn.Linear(128, outputs),
+            nn.LogSoftmax(dim=-1)
         )
         self.saved_log_probs = []
         self.rewards = []

--- a/policy.py
+++ b/policy.py
@@ -18,7 +18,7 @@ class Policy(nn.Module):
             nn.Linear(64 * 22 * 22, 512),
             nn.ReLU(),
             nn.Linear(512, outputs),
-            nn.LogSoftmax(dim=-1)
+            nn.Softmax(dim=-1)
         )
         self.saved_log_probs = []
         self.rewards = []

--- a/trainer.py
+++ b/trainer.py
@@ -20,7 +20,7 @@ class Trainer:
         self.last_epoch = self.policy.load_checkpoint(config['params_path'])
         self.optimizer = torch.optim.Adam(self.policy.parameters(), lr=config['lr'])
 
-    def select_action(self, state):
+    def select_action(self, state, iteration):
         if state is None:  # First state is always None
             # Adding the starting signal as a 0's tensor
             state = np.zeros((self.input_channels, 96, 96))
@@ -33,6 +33,8 @@ class Trainer:
         m = torch.distributions.Categorical(probs)
         action = m.sample()
         self.policy.saved_log_probs.append(m.log_prob(action))
+        self.writer.add_scalar('action prob', m.log_prob(action), iteration)
+        self.writer.add_scalar('entropy', m.entropy(), iteration)
         return available_actions[action.item()]
 
     def episode_train(self, iteration):
@@ -71,8 +73,8 @@ class Trainer:
             i_episode = i_episode + self.last_epoch
             # Collect experience
             state, ep_reward = self.env.reset(), 0
-            for t in range(self.env.spec().max_episode_steps):  # Protecting from scenarios where you are mostly stopped
-                action = self.select_action(state)
+            for t in range(self.env.max_episode_steps()):  # Protecting from scenarios where you are mostly stopped
+                action = self.select_action(state, i_episode * self.env.max_episode_steps() + t)
                 state, reward, done, _ = self.env.step(action)
                 self.policy.rewards.append(reward)
 


### PR DESCRIPTION
I've tried to add the `epsilon` select action strategy to increase explorability. It is not the way done in PPO (thought).
The strategy is start with eps% of time take a random action, take the model one rest of the time. eps decays every n episodes.
Nothing seems to change. When eps = 0, policy is taken. same actions taken all the time

![TensorBoard](https://user-images.githubusercontent.com/613814/110761022-917f5300-824f-11eb-875c-f6334e087b1d.png)

![TensorBoard-2](https://user-images.githubusercontent.com/613814/110761030-93491680-824f-11eb-9b09-e7249c67a0d0.png)

![TensorBoard-3](https://user-images.githubusercontent.com/613814/110761040-95ab7080-824f-11eb-9f64-8d1f637c6731.png)

![TensorBoard-4](https://user-images.githubusercontent.com/613814/110761048-96dc9d80-824f-11eb-923c-3bc72a431a10.png)
