### PR TITLE
PPO - Add hyperparam tuning with ray.tune

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -15,9 +15,8 @@ wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
 chmod +x Miniconda3-latest-Linux-x86_64.sh
 sh Miniconda3-latest-Linux-x86_64.sh
 
-cd idl-2021-wo-rl
-
 conda create --name car-racing python=3.8
 conda activate car-racing
 
-pip install -r requirements
+pip install -r requirements.txt
+pip install git+https://github.com/xeviknal/gym.git@master

--- a/main.py
+++ b/main.py
@@ -1,3 +1,4 @@
+import time
 import torch
 import numpy as np
 from ray import tune
@@ -17,6 +18,8 @@ def train(config):
     torch.manual_seed(seed)
     torch.cuda.manual_seed(seed)
     np.random.seed(seed)
+
+    config['params_path'] = f'./params/policy-params-{experiment}-{int(time.time())}.dl',
 
     # make sure that params folder exists
     helpers.create_directory('params')
@@ -48,7 +51,6 @@ if __name__ == "__main__":
         'stack_frames': 4,
         'device': device,
         'experiment': experiment,
-        'params_path': f'./params/policy-params-{experiment}.dl',
         'action_set_num': 4,
         'train': True,
     }

--- a/main.py
+++ b/main.py
@@ -38,7 +38,7 @@ def train(config):
 
 
 # for concurrent runs and logging
-experiment = 'ppo-nm-hp-tuning'
+experiment = 'ppo-nm-hp-tuning-max'
 if __name__ == "__main__":
     hyperparams = {
         'num_epochs': 1500,  # Number of training episodes

--- a/main.py
+++ b/main.py
@@ -26,12 +26,13 @@ def train(config):
 
     env = CarRacingEnv(device, seed, config['stack_frames'], config['train'])
     helpers.display_start()
-    if config['train']:
-        trainer = Trainer(env, config)
-        trainer.train()
-    else:
-        runner = Runner(env, config)
-        runner.run()
+    # Train it first
+    trainer = Trainer(env, config)
+    trainer.train()
+
+    # Let's store a vid with one episode
+    runner = Runner(env, config)
+    runner.run()
 
 
 # for concurrent runs and logging
@@ -59,7 +60,7 @@ analysis = tune.run(
     train,
     metric='running_reward',
     mode='min',
-    num_samples=10,
+    num_samples=20,
     resources_per_trial={"cpu": 0.5, "gpu": 0.3},
     config=hyperparams,
 )

--- a/main.py
+++ b/main.py
@@ -19,7 +19,7 @@ def train(config):
     torch.cuda.manual_seed(seed)
     np.random.seed(seed)
 
-    config['params_path'] = f'./params/policy-params-{experiment}-{int(time.time())}.dl',
+    config['params_path'] = f'./params/policy-params-{experiment}-{int(time.time())}.dl'
 
     # make sure that params folder exists
     helpers.create_directory('params')

--- a/main.py
+++ b/main.py
@@ -38,7 +38,7 @@ def train(config):
 experiment = 'ppo-nm-hp-tuning'
 if __name__ == "__main__":
     hyperparams = {
-        'num_epochs': 1000,  # Number of training episodes
+        'num_epochs': 2000,  # Number of training episodes
         'num_ppo_epochs': 6,
         'mini_batch_size': 128,
         'memory_size': 2000,

--- a/main.py
+++ b/main.py
@@ -14,7 +14,7 @@ device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
 def train(config):
     # Reproducibility: manual seeding
-    seed = 7081960  # Yann LeCun birthday
+    seed = config['seed']
     torch.manual_seed(seed)
     torch.cuda.manual_seed(seed)
     np.random.seed(seed)
@@ -42,12 +42,12 @@ experiment = 'ppo-nm-hp-tuning-max'
 if __name__ == "__main__":
     hyperparams = {
         'num_epochs': 1500,  # Number of training episodes
-        'num_ppo_epochs': tune.randint(4, 10),
+        'num_ppo_epochs': tune.randint(3, 5),
         'mini_batch_size': 128,
         'memory_size': 2000,
-        'eps': tune.quniform(0.1, 0.2, 0.1),
+        'eps': 0.2,
         'c1': tune.quniform(0.5, 2.5, 0.25),  # Value Function coeff
-        'c2': tune.quniform(0.01, 0.15, 0.01),  # Entropy coeff
+        'c2': tune.quniform(0.00, 0.16, 0.02),  # Entropy coeff
         'lr': 1e-3,  # Learning rate
         'gamma': 0.99,  # Discount rate
         'log_interval': 10,  # controls how often we log progress
@@ -56,13 +56,14 @@ if __name__ == "__main__":
         'experiment': experiment,
         'action_set_num': 4,
         'train': True,
+        'seed': tune.grid_search([7081960, 1000, 190421])
     }
 
 analysis = tune.run(
     train,
     metric='running_reward',
     mode='max',
-    num_samples=20,
+    num_samples=18,
     resources_per_trial={"cpu": 0.4, "gpu": 0.3},
     config=hyperparams,
 )

--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 import torch
 import numpy as np
+from ray import tune
 
 import helpers
 from environment import CarRacingEnv
@@ -9,28 +10,8 @@ from trainer import Trainer
 # if gpu is to be used
 device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
-#for concurrent runs and logging
-experiment='ppo-nm'
-if __name__ == "__main__":
-    hyperparams = {
-        'num_epochs': 25000,  # Number of training episodes
-        'num_ppo_epochs': 10,
-        'mini_batch_size': 128,
-        'memory_size': 2000,
-        'eps': 0.2,
-        'c1': 1.,  # Value Function coeff
-        'c2': 0.01,  # Entropy coeff
-        'lr': 1e-3,  # Learning rate
-        'gamma': 0.99,  # Discount rate
-        'log_interval': 10,  # controls how often we log progress
-        'stack_frames': 4,
-        'device': device,
-        'experiment':experiment,
-        'params_path': f'./params/policy-params-{experiment}.dl',
-        'action_set_num': 0,
-        'train': True
-    }
 
+def train(config):
     # Reproducibility: manual seeding
     seed = 7081960  # Yann LeCun birthday
     torch.manual_seed(seed)
@@ -40,11 +21,42 @@ if __name__ == "__main__":
     # make sure that params folder exists
     helpers.create_directory('params')
 
-    env = CarRacingEnv(device, seed, hyperparams['stack_frames'], hyperparams['train'])
+    env = CarRacingEnv(device, seed, config['stack_frames'], config['train'])
     helpers.display_start()
-    if hyperparams['train']:
-        trainer = Trainer(env, hyperparams)
+    if config['train']:
+        trainer = Trainer(env, config)
         trainer.train()
     else:
-        runner = Runner(env, hyperparams)
+        runner = Runner(env, config)
         runner.run()
+
+
+# for concurrent runs and logging
+experiment = 'ppo-nm-hp-tuning'
+if __name__ == "__main__":
+    hyperparams = {
+        'num_epochs': 1000,  # Number of training episodes
+        'num_ppo_epochs': 6,
+        'mini_batch_size': 128,
+        'memory_size': 2000,
+        'eps': 0.2,
+        'c1': tune.quniform(0.5, 2.5, 0.25),  # Value Function coeff
+        'c2': tune.quniform(0.01, 0.15, 0.01),  # Entropy coeff
+        'lr': 1e-3,  # Learning rate
+        'gamma': 0.99,  # Discount rate
+        'log_interval': 10,  # controls how often we log progress
+        'stack_frames': 4,
+        'device': device,
+        'experiment': experiment,
+        'params_path': f'./params/policy-params-{experiment}.dl',
+        'action_set_num': 0,
+        'train': True,
+    }
+
+analysis = tune.run(
+    train,
+    metric='running_reward',
+    mode='min',
+    num_samples=10,
+    config=hyperparams,
+)

--- a/main.py
+++ b/main.py
@@ -58,5 +58,6 @@ analysis = tune.run(
     metric='running_reward',
     mode='min',
     num_samples=10,
+    resources_per_trial={"gpu": 1},
     config=hyperparams,
 )

--- a/main.py
+++ b/main.py
@@ -41,7 +41,7 @@ def train(config):
 experiment = 'ppo-nm-hp-tuning'
 if __name__ == "__main__":
     hyperparams = {
-        'num_epochs': 700,  # Number of training episodes
+        'num_epochs': 1500,  # Number of training episodes
         'num_ppo_epochs': tune.randint(4, 10),
         'mini_batch_size': 128,
         'memory_size': 2000,
@@ -66,3 +66,9 @@ analysis = tune.run(
     resources_per_trial={"cpu": 0.4, "gpu": 0.3},
     config=hyperparams,
 )
+
+print("Best config: ", analysis.get_best_config(
+    metric="running_reward", mode="max"))
+
+# Get a dataframe for analyzing trial results.
+df = analysis.results_df

--- a/main.py
+++ b/main.py
@@ -58,6 +58,6 @@ analysis = tune.run(
     metric='running_reward',
     mode='min',
     num_samples=10,
-    resources_per_trial={"gpu": 1},
+    resources_per_trial={"cpu": 2, "gpu": 1},
     config=hyperparams,
 )

--- a/main.py
+++ b/main.py
@@ -49,7 +49,7 @@ if __name__ == "__main__":
         'device': device,
         'experiment': experiment,
         'params_path': f'./params/policy-params-{experiment}.dl',
-        'action_set_num': 0,
+        'action_set_num': 4,
         'train': True,
     }
 

--- a/main.py
+++ b/main.py
@@ -38,8 +38,8 @@ def train(config):
 experiment = 'ppo-nm-hp-tuning'
 if __name__ == "__main__":
     hyperparams = {
-        'num_epochs': 2000,  # Number of training episodes
-        'num_ppo_epochs': 6,
+        'num_epochs': 700,  # Number of training episodes
+        'num_ppo_epochs': tune.randint(4, 10),
         'mini_batch_size': 128,
         'memory_size': 2000,
         'eps': 0.2,
@@ -60,6 +60,6 @@ analysis = tune.run(
     metric='running_reward',
     mode='min',
     num_samples=10,
-    resources_per_trial={"cpu": 2, "gpu": 1},
+    resources_per_trial={"cpu": 0.5, "gpu": 0.3},
     config=hyperparams,
 )

--- a/main.py
+++ b/main.py
@@ -31,8 +31,10 @@ def train(config):
     trainer.train()
 
     # Let's store a vid with one episode
+    config['train'] = False
     runner = Runner(env, config)
     runner.run()
+    config['train'] = True
 
 
 # for concurrent runs and logging
@@ -59,8 +61,8 @@ if __name__ == "__main__":
 analysis = tune.run(
     train,
     metric='running_reward',
-    mode='min',
+    mode='max',
     num_samples=20,
-    resources_per_trial={"cpu": 0.5, "gpu": 0.3},
+    resources_per_trial={"cpu": 0.4, "gpu": 0.3},
     config=hyperparams,
 )

--- a/main.py
+++ b/main.py
@@ -45,7 +45,7 @@ if __name__ == "__main__":
         'num_ppo_epochs': tune.randint(4, 10),
         'mini_batch_size': 128,
         'memory_size': 2000,
-        'eps': 0.2,
+        'eps': tune.quniform(0.1, 0.2, 0.1),
         'c1': tune.quniform(0.5, 2.5, 0.25),  # Value Function coeff
         'c2': tune.quniform(0.01, 0.15, 0.01),  # Entropy coeff
         'lr': 1e-3,  # Learning rate

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ torchvision
 opencv-python
 tensorboard
 ray==1.0.1.post1
+ray[tune]

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ torch
 torchvision
 opencv-python
 tensorboard
+ray==1.0.1.post1

--- a/trainer.py
+++ b/trainer.py
@@ -1,3 +1,4 @@
+from ray import tune
 import numpy as np
 import torch
 import torch.nn as nn
@@ -136,6 +137,7 @@ class Trainer:
     def logging_episode(self, i_episode, ep_reward, running_reward):
         self.writer.add_scalar(f'reward', ep_reward, i_episode)
         self.writer.add_scalar(f'running reward', running_reward, i_episode)
+        tune.report(iterations=i_episode, running_reward=running_reward)
 
     def train(self):
         # Training loop


### PR DESCRIPTION
PPO has way more hyperparams compared with REINFORCE ones.
- It is really easy to make the models overfit by doing many passes of the very same transitions
- Loss must be really watched closely in order to inspect its 3 components (and therefore its 2 coefficients)

This PR adds hyperparam tuning tooling to help us see what's the best configuration.