### PR TITLE
Allow users to define hyperparams via process params

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -22,6 +22,15 @@ def show_video():
         print("Could not find video")
 
 
+def print_hyperparams(config):
+    print('----------------------------------------')
+    print("{:<15} {:<10}".format('Param', 'Value'))
+    for label, value in config.items():
+        if label is not "device":
+            print("{:<15} {:<10}".format(label, value))
+    print('----------------------------------------')
+
+
 def display_start():
     display = Display(visible=0, size=(1400, 900))
     display.start()
@@ -29,6 +38,7 @@ def display_start():
 
 def save_model(model, path):
     torch.save(model.state_dict(), path)
+
 
 def create_directory(path):
     try:

--- a/main.py
+++ b/main.py
@@ -1,3 +1,4 @@
+import argparse
 import torch
 import numpy as np
 
@@ -6,32 +7,50 @@ from environment import CarRacingEnv
 from runner import Runner
 from trainers.ppo_trainer import PPOTrainer
 
+parser = argparse.ArgumentParser()
+parser.add_argument("--experiment", help="Name of the experiment", type=str, default="default")
+parser.add_argument("--log_interval", help="Checkpoint frequency", type=int, default=50)
+parser.add_argument("--record", help="Runs the environment and records it", type=bool, default=False)
+parser.add_argument("--epochs", help="Number of epochs to train", type=int, default=25000)
+parser.add_argument("--lr", help="Learning rate", type=float, default=0.001)
+parser.add_argument("--gamma", help="Discount factor", type=float, default=0.99)
+parser.add_argument("--action_set", help="Action set: the set of actions that the policy will use", type=int, default=0)
+parser.add_argument("--ppo_epochs", help="Number of proximal optimization epochs (Only for PPO training)", type=int, default=10)
+parser.add_argument("--ppo_batch_size", help="Batch size for memory visit (Only for PPO training)", type=int, default=128)
+parser.add_argument("--ppo_memory_size", help="Memory size (Only for PPO training)", type=int, default=2000)
+parser.add_argument("--ppo_epsilon", help="Epsilon ratio (Only for PPO training)", type=float, default=0.2)
+parser.add_argument("--ppo_value_coeff", help="Value Function Coeff (Only for PPO training)", type=float, default=1.)
+parser.add_argument("--ppo_entropy_coeff", help="Entropy Coeff (Only for PPO training)", type=float, default=0.01)
+
+args = parser.parse_args()
+
 # if gpu is to be used
 device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
-experiment = 'dev'
 if __name__ == "__main__":
     hyperparams = {
         # Run management params
-        'experiment': experiment,
-        'params_path': f'./params/policy-params-{experiment}.dl',
-        'runs_path': f'./runs/{experiment}',
-        'log_interval': 10,  # controls how often we log progress
+        'experiment': args.experiment,
+        'params_path': f'./params/policy-params-{args.experiment}.dl',
+        'runs_path': f'./runs/{args.experiment}',
+        'log_interval': args.log_interval,  # controls how often we log progress
         'device': device,
-        'train': True,
+        'train': not args.record,
         # Train management
-        'num_epochs': 25000,  # Number of training episodes
-        'num_ppo_epochs': 10,
-        'mini_batch_size': 128,
-        'memory_size': 2000,
-        'eps': 0.2,
-        'c1': 1.,  # Value Function coeff
-        'c2': 0.01,  # Entropy coeff
-        'lr': 1e-3,  # Learning rate
-        'gamma': 0.99,  # Discount rate
+        'num_epochs': args.epochs,  # Number of training episodes
+        'num_ppo_epochs': args.ppo_epochs,
+        'mini_batch_size': args.ppo_batch_size,
+        'memory_size': args.ppo_memory_size,
+        'eps': args.ppo_epsilon,
+        'c1': args.ppo_value_coeff,  # Value Function coeff
+        'c2': args.ppo_entropy_coeff,  # Entropy coeff
+        'lr': args.lr,  # Learning rate
+        'gamma': args.gamma,  # Discount rate
         'stack_frames': 4,
-        'action_set_num': 0,
+        'action_set_num': args.action_set,
     }
+
+    helpers.print_hyperparams(hyperparams)
 
     # Reproducibility: manual seeding
     seed = 7081960  # Yann LeCun birthday


### PR DESCRIPTION
You can call now the process like this:

`python main.py --epochs 1 --log_interval 50 --record false --ppo_batch_size 128 --experiment exp1`

And the first thing the output does is show the selecter hyperparams:

```
----------------------------------------
Param           Value     
experiment      exp1      
params_path     ./params/policy-params-exp1.dl
runs_path       ./runs/exp1
log_interval    50        
train           0         
num_epochs      1         
num_ppo_epochs  10        
mini_batch_size 128       
memory_size     2000      
eps             0.2       
c1              1.0       
c2              0.01      
lr              0.001     
gamma           0.99      
stack_frames    4         
action_set_num  0         
----------------------------------------

```