### PR TITLE
[PPO - early-step / green penalty] Value Function coeff c1 = 2.0, entropy coeff c2 = 0.08

### DIFF
--- a/main.py
+++ b/main.py
@@ -18,8 +18,8 @@ if __name__ == "__main__":
         'mini_batch_size': 128,
         'memory_size': 2000,
         'eps': 0.2,
-        'c1': 1.,  # Value Function coeff
-        'c2': 0.01,  # Entropy coeff
+        'c1': 2.,  # Value Function coeff
+        'c2': 0.08,  # Entropy coeff
         'lr': 1e-3,  # Learning rate
         'gamma': 0.99,  # Discount rate
         'log_interval': 10,  # controls how often we log progress


### PR DESCRIPTION
Playing around with PPO hyperparams we've realized that increasing the value function coeff from 1.0 to 2.0 boosts the training.

The first part of the training (orange) uses the c1 coeff to `1.0` whereas the second part is set to `2.0`.
![c1-10-half-c1-20-half](https://user-images.githubusercontent.com/613814/115145824-db7c0580-a053-11eb-9b39-8649cb422728.png)

However, doing a whole training with `c1=2.0` and `c2=0.08` shows that the model ends ups overfitting and decreasing the entropy radically. 
![c1-2-c2-0 08](https://user-images.githubusercontent.com/613814/115145820-d8811500-a053-11eb-8baa-6dfbb4845452.png)

The `early-stop` wrapper makes it easy to learn how to go fast and ahead. However, after learning this it is not able to learn how to drive through curves.